### PR TITLE
ocpymemcache: add wrappers for Client and HashClient

### DIFF
--- a/ocpymemcache/__init__.py
+++ b/ocpymemcache/__init__.py
@@ -1,0 +1,13 @@
+# Copyright 2018, OpenCensus Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.

--- a/ocpymemcache/client.py
+++ b/ocpymemcache/client.py
@@ -1,0 +1,149 @@
+# Copyright 2018, OpenCensus Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from pymemcache.client.base import Client as PyMemcacheClient
+from ocpymemcache.observability import TrackingOperation
+
+class OCPyMemcacheClient(object):
+    """
+    OCPyMemcacheClient is the instrumented wrapper to provide
+    traces and metrics to a pymemache.client.base.Client instance.
+    It takes the exact arguments that a HashClient would take and
+    underlyingly creates the client which it then wraps.
+    The same usage pattern for the original client would apply here.
+    """
+    
+    __TRACKING_OPERATION = TrackingOperation()
+
+    def __init__(self, server_addr, *args, **kwargs):
+        self.__pymc = PyMemcacheClient(server_addr, *args, **kwargs)
+
+    def add(self, key, value, *args, **kwargs):
+        return self.__TRACKING_OPERATION.trace_and_record_stats(
+                'pymemcache.client.base.Client.add',
+                self.__pymc.add, key, value, *args, **kwargs)
+        
+    def append(self, key, value, *args, **kwargs):
+        return self.__TRACKING_OPERATION.trace_and_record_stats(
+                'pymemcache.client.base.Client.append',
+                self.__pymc.append, key, value, *args, **kwargs)
+
+    def cas(self, key, value, cas, *args, **kwargs):
+        return self.__TRACKING_OPERATION.trace_and_record_stats(
+                'pymemcache.client.base.Client.cas',
+                self.__pymc.cas, key, value, *args, **kwargs)
+
+    def check_key(self, key):
+        # Does not touch the remote end.
+        return self.__pymc.check_key(key)
+
+    def close(self):
+        return self.__TRACKING_OPERATION.trace_and_record_stats(
+                'pymemcache.client.base.Client.close',
+                self.__pymc.close)
+
+    def decr(self, key, value, *args, **kwargs):
+        return self.__TRACKING_OPERATION.trace_and_record_stats(
+                'pymemcache.client.base.Client.decr',
+                self.__pymc.decr, key, value, *args, **kwargs)
+
+    def delete_many(self, keys, *args, **kwargs):
+        return self.__TRACKING_OPERATION.trace_and_record_stats(
+                'pymemcache.client.base.Client.delete_many',
+                self.__pymc.delete_many, key, *args, **kwargs)
+
+    def delete_multi(self, keys, *args, **kwargs):
+        return self.__TRACKING_OPERATION.trace_and_record_stats(
+                'pymemcache.client.base.Client.delete_multi',
+                self.__pymc.delete_multi, keys, *args, **kwargs)
+
+    def flush_all(self, *args, **kwargs):
+        return self.__TRACKING_OPERATION.trace_and_record_stats(
+                'pymemcache.client.base.Client.flush_all',
+                self.__pymc.flush_all, *args, **kwargs)
+
+    def get(self, key, *args, **kwargs):
+        return self.__TRACKING_OPERATION.trace_and_record_stats(
+                'pymemcache.client.base.Client.get',
+                self.__pymc.get, key, *args, **kwargs)
+
+    def get_many(self, keys, *args, **kwargs):
+        return self.__TRACKING_OPERATION.trace_and_record_stats(
+                'pymemcache.client.base.Client.get_many',
+                self.__pymc.get_many, key, *args, **kwargs)
+
+    def get_multi(self, keys, *args, **kwargs):
+        return self.__TRACKING_OPERATION.trace_and_record_stats(
+                'pymemcache.client.base.Client.get_multi',
+                self.__pymc.get_multi, key, *args, **kwargs)
+
+    def gets(self, keys, *args, **kwargs):
+        return self.__TRACKING_OPERATION.trace_and_record_stats(
+                'pymemcache.client.base.Client.gets',
+                self.__pymc.gets, keys, *args, **kwargs)
+
+    def gets_many(self, keys, *args, **kwargs):
+        return self.__TRACKING_OPERATION.trace_and_record_stats(
+                'pymemcache.client.base.Client.gets_many',
+                self.__pymc.gets_many, keys, *args, **kwargs)
+
+    def incr(self, key, value, *args, **kwargs):
+        return self.__TRACKING_OPERATION.trace_and_record_stats(
+                'pymemcache.client.base.Client.incr',
+                self.__pymc.incr, key, value, *args, **kwargs)
+
+    def prepend(self, key, value, *args, **kwargs):
+        return self.__TRACKING_OPERATION.trace_and_record_stats(
+                'pymemcache.client.base.Client.prepend',
+                self.__pymc.prepend, key, value, *args, **kwargs)
+
+    def quit(self, *args, **kwargs):
+        return self.__TRACKING_OPERATION.trace_and_record_stats(
+                'pymemcache.client.base.Client.quit',
+                self.__pymc.quit, *args, **kwargs)
+
+    def replace(self, key, value, *args, **kwargs):
+        return self.__TRACKING_OPERATION.trace_and_record_stats(
+                'pymemcache.client.base.Client.replace',
+                self.__pymc.replace, key, value, *args, **kwargs)
+
+    def set(self, key, value, *args, **kwargs):
+        return self.__TRACKING_OPERATION.trace_and_record_stats(
+                'pymemcache.client.base.Client.set',
+                self.__pymc.set, key, value, *args, **kwargs)
+
+    def set_many(self, values, *args, **kwargs):
+        return self.__TRACKING_OPERATION.trace_and_record_stats(
+                'pymemcache.client.base.Client.set_many',
+                self.__pymc.set_many, values, *args, **kwargs)
+
+    def set_multi(self, values, *args, **kwargs):
+        return self.__TRACKING_OPERATION.trace_and_record_stats(
+                'pymemcache.client.base.Client.set_multi',
+                self.__pymc.set_multi, values, *args, **kwargs)
+
+    def stats(self, *args):
+        return self.__TRACKING_OPERATION.trace_and_record_stats(
+                'pymemcache.client.base.Client.stats',
+                self.__pymc.stats, *args)
+
+    def touch(self, key, *args, **kwargs):
+        return self.__TRACKING_OPERATION.trace_and_record_stats(
+                'pymemcache.client.base.Client.touch',
+                self.__pymc.touch, *args, **kwargs)
+
+    def version(self):
+        return self.__TRACKING_OPERATION.trace_and_record_stats(
+                'pymemcache.client.base.Client.version',
+                self.__pymc.version)

--- a/ocpymemcache/hash_client.py
+++ b/ocpymemcache/hash_client.py
@@ -1,0 +1,149 @@
+# Copyright 2018, OpenCensus Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from pymemcache.client.hash import HashClient as PyMemcacheHashClient
+from ocpymemcache.observability import TrackingOperation
+
+class OCPyMemcacheHashClient(object):
+    """
+    OCPyMemcacheHashClient is the instrumented wrapper to provide
+    traces and metrics to a pymemache.client.hash.HashClient instance.
+    It takes the exact arguments that a HashClient would take and
+    underlyingly creates the client which it then wraps.
+    The same usage pattern for the original client would apply here.
+    """
+    
+    __TRACKING_OPERATION = TrackingOperation()
+
+    def __init__(self, servers, *args, **kwargs):
+        self.__pyhmc = PyMemcacheHashClient(servers, *args, **kwargs)
+
+    def add(self, key, value, *args, **kwargs):
+        return self.__TRACKING_OPERATION.trace_and_record_stats(
+                'pymemcache.client.hash.HashClient.add',
+                self.__pyhmc.add, key, value, *args, **kwargs)
+        
+    def append(self, key, value, *args, **kwargs):
+        return self.__TRACKING_OPERATION.trace_and_record_stats(
+                'pymemcache.client.hash.HashClient.append',
+                self.__pyhmc.append, key, value, *args, **kwargs)
+
+    def cas(self, key, value, cas, *args, **kwargs):
+        return self.__TRACKING_OPERATION.trace_and_record_stats(
+                'pymemcache.client.hash.HashClient.cas',
+                self.__pyhmc.cas, key, value, *args, **kwargs)
+
+    def check_key(self, key):
+        # Does not touch the remote end.
+        return self.__pyhmc.check_key(key)
+
+    def close(self):
+        return self.__TRACKING_OPERATION.trace_and_record_stats(
+                'pymemcache.client.hash.HashClient.close',
+                self.__pyhmc.close)
+
+    def decr(self, key, value, *args, **kwargs):
+        return self.__TRACKING_OPERATION.trace_and_record_stats(
+                'pymemcache.client.hash.HashClient.decr',
+                self.__pyhmc.decr, key, value, *args, **kwargs)
+
+    def delete_many(self, keys, *args, **kwargs):
+        return self.__TRACKING_OPERATION.trace_and_record_stats(
+                'pymemcache.client.hash.HashClient.delete_many',
+                self.__pyhmc.delete_many, key, *args, **kwargs)
+
+    def delete_multi(self, keys, *args, **kwargs):
+        return self.__TRACKING_OPERATION.trace_and_record_stats(
+                'pymemcache.client.hash.HashClient.delete_multi',
+                self.__pyhmc.delete_multi, keys, *args, **kwargs)
+
+    def flush_all(self, *args, **kwargs):
+        return self.__TRACKING_OPERATION.trace_and_record_stats(
+                'pymemcache.client.hash.HashClient.flush_all',
+                self.__pyhmc.flush_all, *args, **kwargs)
+
+    def get(self, key, *args, **kwargs):
+        return self.__TRACKING_OPERATION.trace_and_record_stats(
+                'pymemcache.client.hash.HashClient.get',
+                self.__pyhmc.get, key, *args, **kwargs)
+
+    def get_many(self, keys, *args, **kwargs):
+        return self.__TRACKING_OPERATION.trace_and_record_stats(
+                'pymemcache.client.hash.HashClient.get_many',
+                self.__pyhmc.get_many, key, *args, **kwargs)
+
+    def get_multi(self, keys, *args, **kwargs):
+        return self.__TRACKING_OPERATION.trace_and_record_stats(
+                'pymemcache.client.hash.HashClient.get_multi',
+                self.__pyhmc.get_multi, key, *args, **kwargs)
+
+    def gets(self, keys, *args, **kwargs):
+        return self.__TRACKING_OPERATION.trace_and_record_stats(
+                'pymemcache.client.hash.HashClient.gets',
+                self.__pyhmc.gets, keys, *args, **kwargs)
+
+    def gets_many(self, keys, *args, **kwargs):
+        return self.__TRACKING_OPERATION.trace_and_record_stats(
+                'pymemcache.client.hash.HashClient.gets_many',
+                self.__pyhmc.gets_many, keys, *args, **kwargs)
+
+    def incr(self, key, value, *args, **kwargs):
+        return self.__TRACKING_OPERATION.trace_and_record_stats(
+                'pymemcache.client.hash.HashClient.incr',
+                self.__pyhmc.incr, key, value, *args, **kwargs)
+
+    def prepend(self, key, value, *args, **kwargs):
+        return self.__TRACKING_OPERATION.trace_and_record_stats(
+                'pymemcache.client.hash.HashClient.prepend',
+                self.__pyhmc.prepend, key, value, *args, **kwargs)
+
+    def quit(self, *args, **kwargs):
+        return self.__TRACKING_OPERATION.trace_and_record_stats(
+                'pymemcache.client.hash.HashClient.quit',
+                self.__pyhmc.quit, *args, **kwargs)
+
+    def replace(self, key, value, *args, **kwargs):
+        return self.__TRACKING_OPERATION.trace_and_record_stats(
+                'pymemcache.client.hash.HashClient.replace',
+                self.__pyhmc.replace, key, value, *args, **kwargs)
+
+    def set(self, key, value, *args, **kwargs):
+        return self.__TRACKING_OPERATION.trace_and_record_stats(
+                'pymemcache.client.hash.HashClient.set',
+                self.__pyhmc.set, key, value, *args, **kwargs)
+
+    def set_many(self, values, *args, **kwargs):
+        return self.__TRACKING_OPERATION.trace_and_record_stats(
+                'pymemcache.client.hash.HashClient.set_many',
+                self.__pyhmc.set_many, values, *args, **kwargs)
+
+    def set_multi(self, values, *args, **kwargs):
+        return self.__TRACKING_OPERATION.trace_and_record_stats(
+                'pymemcache.client.hash.HashClient.set_multi',
+                self.__pyhmc.set_multi, values, *args, **kwargs)
+
+    def stats(self, *args):
+        return self.__TRACKING_OPERATION.trace_and_record_stats(
+                'pymemcache.client.hash.HashClient.stats',
+                self.__pyhmc.stats, *args)
+
+    def touch(self, key, *args, **kwargs):
+        return self.__TRACKING_OPERATION.trace_and_record_stats(
+                'pymemcache.client.hash.HashClient.touch',
+                self.__pyhmc.touch, *args, **kwargs)
+
+    def version(self):
+        return self.__TRACKING_OPERATION.trace_and_record_stats(
+                'pymemcache.client.hash.HashClient.version',
+                self.__pyhmc.version)

--- a/ocpymemcache/observability.py
+++ b/ocpymemcache/observability.py
@@ -1,0 +1,83 @@
+# Copyright 2018, OpenCensus Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import time
+
+from opencensus.trace.status import Status
+from opencensus.trace.tracer import Tracer
+
+from opencensus.stats import stats
+from opencensus.stats import aggregation as aggregation_module
+from opencensus.stats import measure as measure_module
+from opencensus.stats import view as view_module
+from opencensus.tags import tag_key as tag_key_module
+from opencensus.tags import tag_map as tag_map_module
+from opencensus.tags import tag_value as tag_value_module
+
+key_method = tag_key_module.TagKey("method")
+key_error  = tag_key_module.TagKey("error")
+key_status = tag_key_module.TagKey("status")
+
+m_latency_ms = measure_module.MeasureFloat("pymemcache/latency", "The latency in milliseconds per method", "ms")
+m_calls = measure_module.MeasureInt("pymemcache/calls", "The number of calls made", "1")
+
+def enable_metrics_views():
+    calls_view = view_module.View("pymemcache/calls", "The number of calls",
+        [key_method, key_error, key_status],
+        m_calls,
+        aggregation_module.CountAggregation())
+
+    latency_view = view_module.View("pymemcache/latency", "The distribution of the latencies",
+        [key_method, key_error, key_status],
+        m_latency_ms,
+        aggregation_module.DistributionAggregation([
+	    # Latency in buckets:
+	    # [>=0ms, >=5ms, >=10ms, >=25ms, >=40ms, >=50ms, >=75ms, >=100ms, >=200ms, >=400ms, >=600ms, >=800ms, >=1s, >=2s, >=4s, >=6s, >=10s, >-20s]
+            0, 5, 10, 25, 40, 50, 75, 100, 200, 400, 600, 800, 1000, 2000, 4000, 6000, 10000, 20000
+        ]))
+
+    view_manager = stats.Stats().view_manager
+    view_manager.register_view(calls_view)
+    view_manager.register_view(latency_view)
+
+class TrackingOperation(object):
+    __TRACER = Tracer()
+    __STATS_RECORDER = stats.Stats().stats_recorder
+
+    def __init__(self):
+        pass
+
+    def trace_and_record_stats(self, method_name, fn, *args, **kwargs):
+        start_time = time.time()
+
+        tags = tag_map_module.TagMap()
+        tags.insert(key_method, tag_value_module.TagValue(method_name))
+        mm = self.__STATS_RECORDER.new_measurement_map()
+
+        with self.__TRACER.span(name=method_name) as span:
+            try:
+                return fn(*args, **kwargs)
+            except Exception as e: # an error to record
+                span.status = Status.from_exception(e)
+                # TODO: (@odeke-em) perhaps shorten the exception when added as a tag here?
+                tags.insert(key_error, e.__str__())
+                # Then finally after recording the exception, re-raise it.
+                raise e
+            else: # Success
+                tags.insert(key_status, "ok")
+            finally:
+                latency_ms = (time.time() - start_time) * 1000
+                mm.measure_float_put(m_latency_ms, latency_ms)
+                mm.measure_int_put(m_calls, 1)
+                mm.record(tags)

--- a/setup.py
+++ b/setup.py
@@ -1,0 +1,50 @@
+# Copyright 2018, OpenCensus Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""A setup module for the PyMemcache wrapper instrumented using OpenCensus"""
+
+import io
+from setuptools import setup, find_packages
+
+install_requires = [
+    'opencensus >= 0.1.7',
+    'pymemcache >= 2.0.0'
+]
+
+setup(
+    name='ocpymemcache',
+    version='0.0.1',
+    author='OpenCensus Authors',
+    author_email='census-developers@googlegroups.com',
+    classifiers=[
+        'Intended Audience :: Developers',
+        'Development Status :: 3 - Alpha',
+        'Intended Audience :: Developers',
+        'License :: OSI Approved :: Apache Software License',
+        'Programming Language :: Python',
+        'Programming Language :: Python :: 2',
+        'Programming Language :: Python :: 2.7',
+        'Programming Language :: Python :: 3',
+        'Programming Language :: Python :: 3.4',
+        'Programming Language :: Python :: 3.5',
+        'Programming Language :: Python :: 3.6',
+    ],
+    description='A wrapper for PyMemcache, instrumented using OpenCensus for distributed tracing and metrics',
+    include_package_data=True,
+    long_description=open('README.md').read(),
+    install_requires=install_requires,
+    license='Apache-2.0',
+    packages=find_packages(),
+    namespace_packages=[],
+    url='https://github.com/opencensus-integrations/ocpymemcache')


### PR DESCRIPTION
Created trace and metric wrappers for the various:
* pymemcache.client.base.Client
* pymemcache.client.hash.HashClient

instances by respectively:

* opcymemcache.client.OCPyMemcacheClient
* opcymemcache.client.OCPyMemcacheHashClient

which for example can be tested out by
```python
from ocpymemcache.client import OCPyMemcacheClient
from ocpymemcache.observability import enable_metrics_views

def main():
    enable_metrics_views()
    ocpymc = OCPyMemcacheClient(('localhost', 11211,))
    print(ocpymc.set('name', 'OpenCensus PyMemcache Demo'))
    print(ocpymc.version())
    print(ocpymc.close())

if __name__ == '__main__':
    main()
```